### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=NeoPixel-Patterns
-version=0.1a
+version=0.1.0-a
 author=Thomas Bennedum
 maintainer=Thomas Bennedum <tab@bennedum.org>
 sentence=Library for patterns using NeoPixel LEDs loosely based on original NeoPatterns library by Adafruit and others.


### PR DESCRIPTION
The previous version value caused the Arduino IDE to display warnings:
```
Invalid version found: 0.1a
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Installing a library with an invalid version causes Arduino IDE 1.8.6 to no longer start.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format